### PR TITLE
feat(CLI): search splits

### DIFF
--- a/.corpora.yaml
+++ b/.corpora.yaml
@@ -1,10 +1,9 @@
-# .corpora.yaml
-
-name: "corpora"
+id: 0d76f20f-e58d-41f6-85af-20f9ee712a20
+name: "skyl/corpora"
 url: "https://github.com/skyl/corpora"
 
 server:
-  base_url: "http://localhost:8000"  # Modify as needed
+  base_url: "http://localhost:8000"
 
 auth:
   # TODO: support 3-legged OAuth for user authentication wit browser

--- a/py/packages/corpora/routers/corpustextfile.py
+++ b/py/packages/corpora/routers/corpustextfile.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.db import IntegrityError
-from ninja import Router
+from ninja import Query, Router
 from ninja.errors import HttpError
 
 from ..lib.files import compute_checksum
@@ -33,6 +33,24 @@ async def create_file(request, payload: FileSchema):
         raise HttpError(409, "A file with this path already exists in the corpus.")
 
     return 201, file
+
+
+# Get file by path, given a corpus ID
+@file_router.get(
+    "/corpus/{corpus_id}", response=FileResponseSchema, operation_id="get_file_by_path"
+)
+@async_raise_not_found
+async def get_file_by_path(
+    request,
+    corpus_id: uuid.UUID,
+    path: str = Query(..., description="Path to the file"),
+):
+    """Retrieve a File by path within a Corpus."""
+
+    ctf = await CorpusTextFile.objects.select_related("corpus").aget(
+        corpus__id=corpus_id, path=path
+    )
+    return ctf
 
 
 @file_router.get("/{file_id}", response=FileResponseSchema, operation_id="get_file")

--- a/py/packages/corpora/routers/corpustextfile.py
+++ b/py/packages/corpora/routers/corpustextfile.py
@@ -13,28 +13,6 @@ from ..auth import BearerAuth
 file_router = Router(tags=["file"], auth=BearerAuth())
 
 
-@file_router.post(
-    "", response={201: FileResponseSchema, 409: str}, operation_id="create_file"
-)
-@async_raise_not_found
-async def create_file(request, payload: FileSchema):
-    """Create a new File within a Corpus."""
-    corpus = await Corpus.objects.aget(id=payload.corpus_id)
-    checksum = compute_checksum(payload.content)
-    try:
-        file = await CorpusTextFile.objects.acreate(
-            path=payload.path,
-            content=payload.content,
-            checksum=checksum,
-            corpus=corpus,
-        )
-    except IntegrityError:
-        # Handle the unique constraint violation for duplicate file paths within the same corpus
-        raise HttpError(409, "A file with this path already exists in the corpus.")
-
-    return 201, file
-
-
 # Get file by path, given a corpus ID
 @file_router.get(
     "/corpus/{corpus_id}", response=FileResponseSchema, operation_id="get_file_by_path"
@@ -59,3 +37,25 @@ async def get_file(request, file_id: uuid.UUID):
     """Retrieve a File by ID."""
     file = await CorpusTextFile.objects.select_related("corpus").aget(id=file_id)
     return file
+
+
+@file_router.post(
+    "", response={201: FileResponseSchema, 409: str}, operation_id="create_file"
+)
+@async_raise_not_found
+async def create_file(request, payload: FileSchema):
+    """Create a new File within a Corpus."""
+    corpus = await Corpus.objects.aget(id=payload.corpus_id)
+    checksum = compute_checksum(payload.content)
+    try:
+        file = await CorpusTextFile.objects.acreate(
+            path=payload.path,
+            content=payload.content,
+            checksum=checksum,
+            corpus=corpus,
+        )
+    except IntegrityError:
+        # Handle the unique constraint violation for duplicate file paths within the same corpus
+        raise HttpError(409, "A file with this path already exists in the corpus.")
+
+    return 201, file

--- a/py/packages/corpora/routers/test_corpustextfile.py
+++ b/py/packages/corpora/routers/test_corpustextfile.py
@@ -11,6 +11,51 @@ client = TestAsyncClient(file_router)
 
 
 class CorpusTextFileAPITestCase(TestCase):
+
+    @pytest.mark.django_db
+    async def test_get_file_by_path(self):
+        """Test retrieving a file by path within a corpus."""
+        user, headers = await create_user_and_token()
+        corpus = await create_corpus(
+            "Path Retrieval Corpus", "https://example.com/repo", user
+        )
+        file = await create_file(corpus, "nested/file1.txt", "Sample content")
+
+        response = await client.get(
+            f"/corpus/{corpus.id}?path=nested/file1.txt", headers=headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["path"] == "nested/file1.txt"
+        assert data["content"] == "Sample content"
+        assert data["corpus_id"] == str(corpus.id)
+
+    @pytest.mark.django_db
+    async def test_get_file_by_path_not_found(self):
+        """Test retrieving a non-existent file by path."""
+        user, headers = await create_user_and_token()
+        corpus = await create_corpus(
+            "Nonexistent File Corpus", "https://example.com/repo", user
+        )
+
+        response = await client.get(
+            f"/corpus/{corpus.id}?path=nonexistent/file.txt", headers=headers
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.django_db
+    async def test_get_file_by_path_missing_query_param(self):
+        """Test retrieving a file by path without providing the required query parameter."""
+        user, headers = await create_user_and_token()
+        corpus = await create_corpus(
+            "Missing Query Param Corpus", "https://example.com/repo", user
+        )
+
+        response = await client.get(f"/corpus/{corpus.id}", headers=headers)
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["msg"] == "Field required"
+        assert response.json()["detail"][0]["loc"] == ["query", "path"]
+
     @pytest.mark.django_db
     async def test_create_file(self):
         """Test creating a file within a corpus."""

--- a/py/packages/corpora_cli/commands/split.py
+++ b/py/packages/corpora_cli/commands/split.py
@@ -1,0 +1,39 @@
+import typer
+
+from corpora_cli.context import ContextObject
+from corpora_client.models.split_vector_search_schema import SplitVectorSearchSchema
+
+app = typer.Typer(help="Split commands")
+
+
+@app.command()
+def search(ctx: typer.Context, text: str, limit: int = 10):
+    """Search for splits."""
+    if not text:
+        raise typer.BadParameter("Missing argument 'TEXT'")
+    if limit < 1:
+        raise typer.BadParameter("Limit must be greater than 0")
+    print(f"FFFUCK {text}, {limit}")
+    c: ContextObject = ctx.obj
+    # c.corpus_api.get_corpus()
+    c.console.print("Searching for splits...")
+    query = SplitVectorSearchSchema(
+        # TODO: how do we really want to identify the corpus?
+        corpus_id=c.config["id"],
+        text=text,
+        limit=limit,
+    )
+    res = c.split_api.vector_search(query)
+    for split in res:
+        # c.console.print(f"File ID: {split.file_id}")
+        phial = c.file_api.get_file(split.file_id)
+        c.console.print(f"File: {phial.path}")
+        c.console.print(f"{split.order} {split.content[:100]}", style="dim")
+        # c.console.print(phial.content[:100], style="dim")
+
+
+@app.command()
+def ask(ctx: typer.Context, text: str):
+    """Ask for splits."""
+    c: ContextObject = ctx.obj
+    c.console.print("Asking for splits...")

--- a/py/packages/corpora_cli/commands/split.py
+++ b/py/packages/corpora_cli/commands/split.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 import typer
 
 from corpora_cli.context import ContextObject
@@ -13,7 +14,6 @@ def search(ctx: typer.Context, text: str, limit: int = 10):
         raise typer.BadParameter("Missing argument 'TEXT'")
     if limit < 1:
         raise typer.BadParameter("Limit must be greater than 0")
-    print(f"FFFUCK {text}, {limit}")
     c: ContextObject = ctx.obj
     # c.corpus_api.get_corpus()
     c.console.print("Searching for splits...")
@@ -33,7 +33,11 @@ def search(ctx: typer.Context, text: str, limit: int = 10):
 
 
 @app.command()
-def ask(ctx: typer.Context, text: str):
+def list(ctx: typer.Context, file_path: str):
     """Ask for splits."""
     c: ContextObject = ctx.obj
-    c.console.print("Asking for splits...")
+    c.console.print(f"Asking for splits... {file_path}")
+    fil = c.file_api.get_file_by_path(corpus_id=c.config["id"], path=file_path)
+    splits = c.split_api.list_splits_for_file(fil.id)
+    for split in splits:
+        c.console.print(f"{split.order} {split.content[:100]}", style="dim")

--- a/py/packages/corpora_cli/commands/split.py
+++ b/py/packages/corpora_cli/commands/split.py
@@ -9,13 +9,12 @@ app = typer.Typer(help="Split commands")
 
 @app.command()
 def search(ctx: typer.Context, text: str, limit: int = 10):
-    """Search for splits."""
+    """Search for splits in the corpus with a given text."""
     if not text:
         raise typer.BadParameter("Missing argument 'TEXT'")
     if limit < 1:
         raise typer.BadParameter("Limit must be greater than 0")
     c: ContextObject = ctx.obj
-    # c.corpus_api.get_corpus()
     c.console.print("Searching for splits...")
     query = SplitVectorSearchSchema(
         # TODO: how do we really want to identify the corpus?
@@ -34,7 +33,7 @@ def search(ctx: typer.Context, text: str, limit: int = 10):
 
 @app.command()
 def list(ctx: typer.Context, file_path: str):
-    """Ask for splits."""
+    """List all splits for a specific file."""
     c: ContextObject = ctx.obj
     c.console.print(f"Asking for splits... {file_path}")
     fil = c.file_api.get_file_by_path(corpus_id=c.config["id"], path=file_path)

--- a/py/packages/corpora_cli/commands/test_split.py
+++ b/py/packages/corpora_cli/commands/test_split.py
@@ -1,0 +1,110 @@
+from io import StringIO
+from unittest.mock import patch, MagicMock
+from typer.testing import CliRunner
+from rich.console import Console
+
+# from corpora_client.models.split_vector_search_schema import SplitVectorSearchSchema
+from corpora_client.api.split_api import SplitApi
+from corpora_cli.context import ContextObject
+from corpora_cli.commands.split import app  # Adjust if the path is different
+
+runner = CliRunner()
+
+
+@patch("corpora_cli.commands.split.ContextObject")
+def test_search_command(mock_context):
+    """Test the `search` command for splits."""
+    console_output = StringIO()
+    real_console = Console(file=console_output)
+
+    mock_context_instance = mock_context.return_value
+    mock_context_instance.console = real_console
+    mock_context_instance.config = {"id": "test_corpus_id"}
+
+    # Mock APIs
+    mock_context_instance.split_api.vector_search.return_value = [
+        MagicMock(file_id="file123", order=1, content="This is the first split..."),
+        MagicMock(file_id="file456", order=2, content="This is the second split..."),
+    ]
+    mock_context_instance.file_api.get_file.side_effect = [
+        MagicMock(path="/path/to/file1"),
+        MagicMock(path="/path/to/file2"),
+    ]
+
+    # Run the command
+    result = runner.invoke(
+        app,
+        ["search", "example search", "--limit", "2"],
+        # this frustratingly doesn't work
+        # ["search", "example search", "2"],
+        obj=mock_context_instance,
+    )
+    output = console_output.getvalue()
+
+    # Debugging Output
+    print(f"CLI Output:\n{output}")
+    print(f"Result Exit Code: {result.exit_code}")
+    print(f"Result Output: {result.stdout}")
+
+    # Assertions
+    assert result.exit_code == 0
+    assert "Searching for splits..." in output
+    assert "File: /path/to/file1" in output
+    assert "1 This is the first split..." in output
+    assert "File: /path/to/file2" in output
+    assert "2 This is the second split..." in output
+
+
+# @patch("corpora_cli.commands.split.ContextObject")
+# def test_search_no_results(mock_context_class):
+#     """Test the search command with no results."""
+#     console_output = StringIO()
+#     real_console = Console(file=console_output)
+
+#     mock_context_instance = mock_context_class.return_value
+#     mock_context_instance.console = real_console
+#     mock_context_instance.config = {"id": "test_corpus_id"}
+#     mock_context_instance.split_api = MagicMock(spec=SplitApi)
+
+#     # Mock split_api response with no results
+#     mock_context_instance.split_api.vector_search.return_value = []
+
+#     result = runner.invoke(app, ["search 'example search'"], obj=mock_context_instance)
+#     output = console_output.getvalue()
+
+#     assert result.exit_code == 0
+#     assert "Searching for splits..." in output
+#     assert "No splits found." in output
+
+
+@patch("corpora_cli.commands.split.ContextObject")
+def test_search_invalid_input(mock_context_class):
+    """Test the search command with invalid inputs."""
+    console_output = StringIO()
+    real_console = Console(file=console_output)
+
+    mock_context_instance = mock_context_class.return_value
+    mock_context_instance.console = real_console
+
+    # # Missing text argument
+    # result = runner.invoke(app, ["search"], obj=mock_context_instance)
+    # output = console_output.getvalue()
+    # assert result.exit_code != 0
+    # print(f"CLI Output:\n{output}")
+    # print(f"Result Exit Code: {result.exit_code}")
+    # print(f"Result Output: {result.stdout}")
+
+    # assert "Missing argument 'TEXT'" in result.stdout
+
+    # Invalid limit
+    result = runner.invoke(
+        app,
+        ["search", '"example search"', "--limit", "0"],
+        obj=mock_context_instance,
+    )
+    output = console_output.getvalue()
+    assert result.exit_code != 0
+    print(f"CLI Output:\n{output}")
+    print(f"Result Exit Code: {result.exit_code}")
+    print(f"Result Output: {result.stdout}")
+    assert "Limit must be greater than 0" in result.stdout

--- a/py/packages/corpora_cli/main.py
+++ b/py/packages/corpora_cli/main.py
@@ -4,7 +4,7 @@ from rich.console import Console
 from rich.text import Text
 
 import corpora_client
-from corpora_cli.commands import corpus, file
+from corpora_cli.commands import corpus, file, split
 from corpora_cli.config import load_config
 from corpora_cli.auth import AuthResolver, AuthError
 from corpora_cli.constants import NO_AUTHENTICATION_MESSAGE
@@ -59,6 +59,7 @@ def main(ctx: typer.Context):
 # Register commands with the app
 app.add_typer(corpus.app, name="corpus", help="Commands for managing corpora")
 app.add_typer(file.app, name="file", help="Commands for file operations")
+app.add_typer(split.app, name="split", help="Commands for split operations")
 
 if __name__ == "__main__":
     app()

--- a/py/packages/corpora_client/README.md
+++ b/py/packages/corpora_client/README.md
@@ -102,6 +102,7 @@ Class | Method | HTTP request | Description
 *CorpusApi* | [**list_corpora**](docs/CorpusApi.md#list_corpora) | **GET** /api/corpora/corpus | List Corpora
 *FileApi* | [**create_file**](docs/FileApi.md#create_file) | **POST** /api/corpora/file | Create File
 *FileApi* | [**get_file**](docs/FileApi.md#get_file) | **GET** /api/corpora/file/{file_id} | Get File
+*FileApi* | [**get_file_by_path**](docs/FileApi.md#get_file_by_path) | **GET** /api/corpora/file/corpus/{corpus_id} | Get File By Path
 *SplitApi* | [**get_split**](docs/SplitApi.md#get_split) | **GET** /api/corpora/split/{split_id} | Get Split
 *SplitApi* | [**list_splits_for_file**](docs/SplitApi.md#list_splits_for_file) | **GET** /api/corpora/split/file/{file_id} | List Splits For File
 *SplitApi* | [**vector_search**](docs/SplitApi.md#vector_search) | **POST** /api/corpora/split/search | Vector Search

--- a/py/packages/corpora_client/api/file_api.py
+++ b/py/packages/corpora_client/api/file_api.py
@@ -16,7 +16,8 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import StrictStr
+from pydantic import Field, StrictStr
+from typing_extensions import Annotated
 from corpora_client.models.file_response_schema import FileResponseSchema
 from corpora_client.models.file_schema import FileSchema
 
@@ -522,6 +523,265 @@ class FileApi:
         return self.api_client.param_serialize(
             method="GET",
             resource_path="/api/corpora/file/{file_id}",
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth,
+        )
+
+    @validate_call
+    def get_file_by_path(
+        self,
+        corpus_id: StrictStr,
+        path: Annotated[StrictStr, Field(description="Path to the file")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> FileResponseSchema:
+        """Get File By Path
+
+        Retrieve a File by path within a Corpus.
+
+        :param corpus_id: (required)
+        :type corpus_id: str
+        :param path: Path to the file (required)
+        :type path: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._get_file_by_path_serialize(
+            corpus_id=corpus_id,
+            path=path,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "FileResponseSchema",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+    @validate_call
+    def get_file_by_path_with_http_info(
+        self,
+        corpus_id: StrictStr,
+        path: Annotated[StrictStr, Field(description="Path to the file")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[FileResponseSchema]:
+        """Get File By Path
+
+        Retrieve a File by path within a Corpus.
+
+        :param corpus_id: (required)
+        :type corpus_id: str
+        :param path: Path to the file (required)
+        :type path: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._get_file_by_path_serialize(
+            corpus_id=corpus_id,
+            path=path,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "FileResponseSchema",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+    @validate_call
+    def get_file_by_path_without_preload_content(
+        self,
+        corpus_id: StrictStr,
+        path: Annotated[StrictStr, Field(description="Path to the file")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get File By Path
+
+        Retrieve a File by path within a Corpus.
+
+        :param corpus_id: (required)
+        :type corpus_id: str
+        :param path: Path to the file (required)
+        :type path: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._get_file_by_path_serialize(
+            corpus_id=corpus_id,
+            path=path,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "FileResponseSchema",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+    def _get_file_by_path_serialize(
+        self,
+        corpus_id,
+        path,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {}
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if corpus_id is not None:
+            _path_params["corpus_id"] = corpus_id
+        # process the query parameters
+        if path is not None:
+
+            _query_params.append(("path", path))
+
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+        # set the HTTP header `Accept`
+        if "Accept" not in _header_params:
+            _header_params["Accept"] = self.api_client.select_header_accept(
+                ["application/json"]
+            )
+
+        # authentication setting
+        _auth_settings: List[str] = ["BearerAuth"]
+
+        return self.api_client.param_serialize(
+            method="GET",
+            resource_path="/api/corpora/file/corpus/{corpus_id}",
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/py/packages/corpora_client/docs/FileApi.md
+++ b/py/packages/corpora_client/docs/FileApi.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**create_file**](FileApi.md#create_file) | **POST** /api/corpora/file | Create File
 [**get_file**](FileApi.md#get_file) | **GET** /api/corpora/file/{file_id} | Get File
+[**get_file_by_path**](FileApi.md#get_file_by_path) | **GET** /api/corpora/file/corpus/{corpus_id} | Get File By Path
 
 
 # **create_file**
@@ -144,6 +145,86 @@ with corpora_client.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **file_id** | **str**|  | 
+
+### Return type
+
+[**FileResponseSchema**](FileResponseSchema.md)
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | OK |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **get_file_by_path**
+> FileResponseSchema get_file_by_path(corpus_id, path)
+
+Get File By Path
+
+Retrieve a File by path within a Corpus.
+
+### Example
+
+* Bearer Authentication (BearerAuth):
+
+```python
+import corpora_client
+from corpora_client.models.file_response_schema import FileResponseSchema
+from corpora_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = corpora_client.Configuration(
+    host = "http://localhost"
+)
+
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure Bearer authorization: BearerAuth
+configuration = corpora_client.Configuration(
+    access_token = os.environ["BEARER_TOKEN"]
+)
+
+# Enter a context with an instance of the API client
+with corpora_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = corpora_client.FileApi(api_client)
+    corpus_id = 'corpus_id_example' # str | 
+    path = 'path_example' # str | Path to the file
+
+    try:
+        # Get File By Path
+        api_response = api_instance.get_file_by_path(corpus_id, path)
+        print("The response of FileApi->get_file_by_path:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling FileApi->get_file_by_path: %s\n" % e)
+```
+
+
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **corpus_id** | **str**|  | 
+ **path** | **str**| Path to the file | 
 
 ### Return type
 

--- a/py/packages/corpora_client/test/test_file_api.py
+++ b/py/packages/corpora_client/test/test_file_api.py
@@ -40,6 +40,13 @@ class TestFileApi(unittest.TestCase):
         """
         pass
 
+    def test_get_file_by_path(self) -> None:
+        """Test case for get_file_by_path
+
+        Get File By Path
+        """
+        pass
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a new endpoint in the `corpus` router to retrieve files by path within a corpus.
- Introduced CLI commands for searching and listing splits, enhancing the CLI's functionality.
- Implemented tests for the new CLI split search command, ensuring robustness and reliability.
- Updated the File API to include methods for retrieving files by path, with proper serialization and deserialization.
- Enhanced documentation to reflect the new API methods and CLI commands.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>corpustextfile.py</strong><dd><code>Add endpoint to retrieve file by path in corpus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora/routers/corpustextfile.py

<li>Added a new endpoint to retrieve a file by path within a corpus.<br> <li> Utilized <code>Query</code> from <code>ninja</code> for path parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-76b598a80f83577973d8fd235d1c9bde05a20e944ac96b5e438fc62f28338146">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>split.py</strong><dd><code>Add CLI commands for split search and listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_cli/commands/split.py

<li>Introduced CLI commands for searching and listing splits.<br> <li> Implemented search functionality with text and limit parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-05454f1a232d5d3506ccbd1c61a8074269ec8cc48e9d7f8f2f8639f1787708a0">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Register split commands in CLI application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_cli/main.py

- Registered new split commands with the CLI application.



</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-d28ced86f8c52ace028647cedc64dafae962563c0c633ef72e172eab12e92aa5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>file_api.py</strong><dd><code>Add file retrieval by path in File API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_client/api/file_api.py

<li>Added methods to retrieve a file by path in the File API.<br> <li> Implemented serialization and deserialization for the new endpoint.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-c41ca306db27154d7a2ddee2098ad519a866e620163fefaea286526d6073902b">+261/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_split.py</strong><dd><code>Add tests for CLI split search command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_cli/commands/test_split.py

<li>Added tests for the new CLI split search command.<br> <li> Included test cases for valid and invalid inputs.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-4086b5dc9d285bb15f4e2974b331290e452190f52eadc37f1ae67ba203cd447e">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_file_api.py</strong><dd><code>Add test case for get_file_by_path method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_client/test/test_file_api.py

- Added a placeholder test case for the new get_file_by_path method.



</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-f71b8d7642aa2d12be30300eaaf32d26f7cc4e8bcbead411908f3c647f6120de">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>.corpora.yaml</strong><dd><code>Update project configuration details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.corpora.yaml

- Updated project ID and name in configuration.



</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-589b7cecdd996f75f823a56e2d53f47156d96b811312eca1a227a619c0ab9da1">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document get_file_by_path method in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_client/README.md

- Documented the new get_file_by_path method in the File API.



</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-9ed923da2950d71841f1f37b2d40f4a36f97643423c22c32f568f3f9860558fb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FileApi.md</strong><dd><code>Add documentation for get_file_by_path API method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_client/docs/FileApi.md

- Added documentation for the get_file_by_path API method.



</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/19/files#diff-f83e4f15f236a959c56f44389eccc887780d084fbb06fe1e1c5942e394c9227f">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information