### PR TITLE
feat(rs/core/corpora_cli/commands/workon): file revisions via rust CLI -> API

### DIFF
--- a/rs/core/corpora_cli/src/commands/workon.rs
+++ b/rs/core/corpora_cli/src/commands/workon.rs
@@ -136,7 +136,7 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
             .interact()
             .unwrap()
         {
-            let mut file = File::create(&relative_path).expect("Failed to open file");
+            let mut file = File::create(&path).expect("Failed to open file");
             file.write_all(revision.as_bytes())
                 .expect("Failed to write file");
             ctx.success("File written!");

--- a/rs/core/corpora_cli/src/commands/workon.rs
+++ b/rs/core/corpora_cli/src/commands/workon.rs
@@ -1,15 +1,118 @@
 use crate::context::Context;
 use clap::Args;
+use corpora_client::models::{CorpusFileChatSchema, MessageSchema};
+use dialoguer::{theme::ColorfulTheme, Confirm, Input};
+use std::fs::{self, File};
+use std::io::Write;
 
-/// The `workon` command arguments
 #[derive(Args)]
 pub struct WorkonArgs {
     #[arg(help = "Path to the file or directory")]
     pub path: String,
 }
 
-/// Run the `workon` command
+/// The `workon` command operation
 pub fn run(ctx: &Context, args: WorkonArgs) {
-    println!("Workon command executed with path: {}", args.path);
-    println!("Server URL: {}", ctx.api_config.base_path);
+    let path = args.path.clone();
+    ctx.success(&format!("Working on file: {}", path));
+    let ext = path.split('.').last().unwrap_or("");
+
+    // Show current file content, load the content from the
+    // CWD and print it with dim
+    let current_file_content = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(_) => {
+            File::create(&path).expect("Failed to create file");
+            String::new()
+        }
+    };
+
+    ctx.success("Current file content:");
+    println!("{}", current_file_content);
+
+    let mut messages: Vec<MessageSchema> = Vec::new();
+
+    if !current_file_content.is_empty() {
+        messages.push(MessageSchema {
+            role: "user".to_string(),
+            text: format!(
+                "The original file content was:\n```{}\n{}```",
+                ext, current_file_content
+            ),
+        });
+    }
+
+    // REPL loop
+    loop {
+        let user_input: String = Input::with_theme(&ColorfulTheme::default())
+            .with_prompt(if messages.is_empty() {
+                "What to do?"
+            } else {
+                "How to revise?"
+            })
+            .allow_empty(false)
+            .interact_text()
+            .unwrap();
+
+        // Add the user's input as a new message
+        messages.push(MessageSchema {
+            role: "user".to_string(),
+            text: user_input.trim().to_string(),
+        });
+
+        // Generate revision
+        ctx.success("Generating revision...");
+
+        let root_path = &ctx.corpora_config.root_path;
+        let voice = fs::read_to_string(root_path.join(".corpora/VOICE.md")).unwrap_or_default();
+        let purpose = fs::read_to_string(root_path.join(".corpora/PURPOSE.md")).unwrap_or_default();
+        let structure =
+            fs::read_to_string(root_path.join(".corpora/STRUCTURE.md")).unwrap_or_default();
+        let directions =
+            fs::read_to_string(root_path.join(format!(".corpora/{}/DIRECTIONS.md", ext)))
+                .unwrap_or_default();
+
+        let revision = match corpora_client::apis::workon_api::file(
+            &ctx.api_config,
+            CorpusFileChatSchema {
+                messages: messages.clone(),
+                corpus_id: ctx
+                    .corpora_config
+                    .id
+                    .clone()
+                    .expect("Failed to get corpus ID"),
+                path: path.clone(),
+                voice: Some(voice),
+                purpose: Some(purpose),
+                structure: Some(structure),
+                directions: Some(directions),
+            },
+        ) {
+            Ok(response) => response,
+            Err(err) => {
+                ctx.error(&format!("Failed to generate revision: {:?}", err));
+                continue;
+            }
+        };
+
+        println!("{}", revision);
+        println!("{}", path);
+        messages.push(MessageSchema {
+            role: "assistant".to_string(),
+            text: revision.clone(),
+        });
+
+        if Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Write file?")
+            .interact()
+            .unwrap()
+        {
+            let mut file = File::create(&path).expect("Failed to open file");
+            file.write_all(revision.as_bytes())
+                .expect("Failed to write file");
+            ctx.success("File written!");
+        } else {
+            ctx.warn("You chose not to write the file. Give more input to revise.");
+        }
+    }
 }

--- a/rs/core/corpora_cli/src/commands/workon.rs
+++ b/rs/core/corpora_cli/src/commands/workon.rs
@@ -43,7 +43,7 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
     let current_file_content = match fs::read_to_string(path) {
         Ok(content) => content,
         Err(_) => {
-            File::create(&path).expect("Failed to create file");
+            File::create(path).expect("Failed to create file");
             String::new()
         }
     };
@@ -136,7 +136,7 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
             .interact()
             .unwrap()
         {
-            let mut file = File::create(&path).expect("Failed to open file");
+            let mut file = File::create(path).expect("Failed to open file");
             file.write_all(revision.as_bytes())
                 .expect("Failed to write file");
             ctx.success("File written!");


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `workon` command to handle file paths and display the current working directory.
- Implemented a REPL loop for user interaction, allowing users to input revision instructions.
- Integrated with the `corpora_client` API to generate file revisions based on user input.
- Added functionality to confirm and write the generated revisions back to the file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workon.rs</strong><dd><code>Implement `workon` command with file revision and REPL loop</code></dd></summary>
<hr>

rs/core/corpora_cli/src/commands/workon.rs

<li>Added functionality to handle file paths and display current working <br>directory.<br> <li> Implemented a REPL loop for user interaction and file revision <br>generation.<br> <li> Integrated with <code>corpora_client</code> API to generate file revisions.<br> <li> Added user confirmation for writing revisions back to the file.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/55/files#diff-e8486ee89ebf16ff450393704ed1bda8ca8222231ba8dc254270317294b85a76">+136/-4</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information