### PR TITLE
feat(static): build openssl for fully static corpora in another arm64 linux container

### DIFF
--- a/docker/Dockerfile.xcompile
+++ b/docker/Dockerfile.xcompile
@@ -1,26 +1,33 @@
-# Start with Alpine for its Musl-based minimal footprint
-FROM alpine:latest
+# Use Alpine for its minimal footprint and musl support
+FROM alpine:latest as builder
 
-# Install necessary tools and libraries for Rust and Musl
+# Install necessary build tools
 RUN apk add --no-cache \
-    musl-dev \
     build-base \
-    linux-headers \
+    musl-dev \
     openssl-dev \
     curl \
     perl \
+    linux-headers \
+    gcc \
     git
 
-# Install Rust and add the Musl target
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
-    && source $HOME/.cargo/env \
-    && rustup target add x86_64-unknown-linux-musl
+# Set environment variables for Musl and OpenSSL
+ENV CC=musl-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+    OPENSSL_DIR=/usr \
+    OPENSSL_LIB_DIR=/usr/lib \
+    OPENSSL_INCLUDE_DIR=/usr/include
 
-# Set up environment variables for Musl builds
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:$PATH"
 
-# Set the working directory inside the container
+# Add the musl target to Rust
+RUN rustup target add aarch64-unknown-linux-musl
+
+# Define the working directory
 WORKDIR /workspace
 
-# Default command to prevent the container from exiting immediately
+# Default command for interactive debugging
 CMD ["/bin/sh"]

--- a/docker/Dockerfile.xcompile
+++ b/docker/Dockerfile.xcompile
@@ -1,33 +1,42 @@
-# Use Alpine for its minimal footprint and musl support
+# Use Alpine for its musl-based environment
 FROM alpine:latest as builder
 
-# Install necessary build tools
+# Install required tools
 RUN apk add --no-cache \
     build-base \
     musl-dev \
-    openssl-dev \
-    curl \
-    perl \
     linux-headers \
+    perl \
+    curl \
+    git \
     gcc \
-    git
+    make
 
-# Set environment variables for Musl and OpenSSL
-ENV CC=musl-gcc \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
-    OPENSSL_DIR=/usr \
-    OPENSSL_LIB_DIR=/usr/lib \
-    OPENSSL_INCLUDE_DIR=/usr/include
+# Build OpenSSL statically for musl
+WORKDIR /openssl
+RUN curl -O -L https://www.openssl.org/source/openssl-3.4.0.tar.gz \
+    && tar -xzf openssl-3.4.0.tar.gz \
+    && cd openssl-3.4.0 \
+    && CC=gcc ./Configure no-shared no-zlib linux-aarch64 \
+    && make -j$(nproc) \
+    && make install_sw
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:$PATH"
 
-# Add the musl target to Rust
+# Add musl target
 RUN rustup target add aarch64-unknown-linux-musl
 
-# Define the working directory
+# Set environment variables for static linking with OpenSSL
+ENV OPENSSL_DIR=/usr/local \
+    OPENSSL_LIB_DIR=/usr/local/lib \
+    OPENSSL_INCLUDE_DIR=/usr/local/include \
+    CC=gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=gcc
+
+# Define working directory
 WORKDIR /workspace
 
-# Default command for interactive debugging
+# Default command
 CMD ["/bin/sh"]

--- a/py/packages/corpora_proj/urls.py
+++ b/py/packages/corpora_proj/urls.py
@@ -23,5 +23,5 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += [
-        path("bin/<str:arch>/", BinaryView.as_view(), name="binary"),
+        path("bin/<str:arch>", BinaryView.as_view(), name="binary"),
     ]


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Removed the trailing slash from the 'bin' path in the URL pattern in `urls.py` to ensure consistency in URL handling.
- Updated `Dockerfile.xcompile` to build OpenSSL statically for musl, reorganized the installation of tools, and added environment variables for static linking.
- Added musl target for Rust in the Dockerfile to support static builds.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>urls.py</strong><dd><code>Remove trailing slash from URL pattern in debug mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/packages/corpora_proj/urls.py

- Removed trailing slash from the 'bin' path in the URL pattern.



</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/60/files#diff-6f646987510055c8035672adbed0e857c12ed85973f05f627286fb3d446894b5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.xcompile</strong><dd><code>Update Dockerfile for static OpenSSL and musl target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/Dockerfile.xcompile

<li>Reorganized Dockerfile for building static binaries.<br> <li> Added static OpenSSL build for musl.<br> <li> Updated environment variables for static linking.<br> <li> Added musl target for Rust.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/60/files#diff-94a0d39409439edeb63eb694c48bf3f4a978f6df278ce6a2fd47ee7a04e3874e">+30/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information