### PR TITLE
feat(cli): use editor for workon and chat on rs CLI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
       CORPORA_CLIENT_SECRET: "${CORPORA_CLIENT_SECRET}"
       GITHUB_TOKEN: "${GITHUB_TOKEN}"
       # OPENAI_API_KEY: "${OPENAI_API_KEY}"
+      # EDITOR: "code"
     command: sleep infinity
     working_dir: /workspace
     networks:

--- a/rs/core/corpora_cli/src/commands/chat.rs
+++ b/rs/core/corpora_cli/src/commands/chat.rs
@@ -1,6 +1,5 @@
 use crate::context::Context;
 use corpora_client::models::{CorpusChatSchema, MessageSchema};
-use dialoguer::{theme::ColorfulTheme, Input};
 use std::fs;
 use termimad::MadSkin;
 
@@ -10,13 +9,15 @@ pub fn run(ctx: &Context) {
 
     // REPL loop
     loop {
-        // TODO: multiline input
-        let user_input: String = Input::with_theme(&ColorfulTheme::default())
-            .with_prompt("Can I help you?")
-            .allow_empty(false)
-            .interact_text()
-            .unwrap();
-
+        // // TODO: multiline input
+        // let user_input: String = Input::with_theme(&ColorfulTheme::default())
+        //     .with_prompt("Can I help you?")
+        //     .allow_empty(false)
+        //     .interact_text()
+        //     .unwrap();
+        let user_input = ctx
+            .get_user_input_via_editor("Put your prompt here and close")
+            .expect("FML");
         // Add the user's input as a new message
         messages.push(MessageSchema {
             role: "user".to_string(),

--- a/rs/core/corpora_cli/src/commands/workon.rs
+++ b/rs/core/corpora_cli/src/commands/workon.rs
@@ -63,7 +63,10 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
         //     .interact_text()
         //     .unwrap();
         let user_input = ctx
-            .get_user_input_via_editor("Put prompt here")
+            .get_user_input_via_editor(&format!(
+                "Put your prompt here for {}, save and close",
+                path.display()
+            ))
             .expect("Failed to get user input");
 
         // Add the user's input as a new message

--- a/rs/core/corpora_cli/src/commands/workon.rs
+++ b/rs/core/corpora_cli/src/commands/workon.rs
@@ -1,7 +1,7 @@
 use crate::context::Context;
 use clap::Args;
 use corpora_client::models::{CorpusFileChatSchema, MessageSchema};
-use dialoguer::{theme::ColorfulTheme, Confirm, Input};
+use dialoguer::{theme::ColorfulTheme, Confirm};
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
@@ -14,32 +14,21 @@ pub struct WorkonArgs {
 
 /// The `workon` command operation
 pub fn run(ctx: &Context, args: WorkonArgs) {
-    // get path as a path from the string
     let path = Path::new(&args.path);
-    // get cwd
     let cwd = std::env::current_dir().unwrap();
-    ctx.print(
-        &format!("Current working directory: {}", cwd.display()),
-        dialoguer::console::Style::new().dim(),
-    );
-    // add cwd and args.path
+    ctx.dim(&format!("Current working directory: {}", cwd.display()));
     let absolute_path = Path::join(&cwd, path);
-    // rm the config.root_path to get the relative path
     let relative_path = absolute_path
         .strip_prefix(&ctx.corpora_config.root_path)
         .unwrap();
-    // ctx.success(&format!("Working on file: {}", relative_path.display()));
-    ctx.print(
-        &format!("Working on file: {}", relative_path.display()),
-        dialoguer::console::Style::new().dim().green(),
-    );
+
+    ctx.magenta(&format!("Working on file: {}", relative_path.display()));
     let ext = relative_path
         .extension()
         .unwrap_or_default()
         .to_str()
         .unwrap_or("");
 
-    // Show current file content, load the content from the
     let current_file_content = match fs::read_to_string(path) {
         Ok(content) => content,
         Err(_) => {
@@ -47,15 +36,10 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
             String::new()
         }
     };
-
     ctx.success("Current file content:");
-    ctx.print(
-        &current_file_content,
-        dialoguer::console::Style::new().dim(),
-    );
+    ctx.dim(&current_file_content);
 
     let mut messages: Vec<MessageSchema> = Vec::new();
-
     if !current_file_content.is_empty() {
         messages.push(MessageSchema {
             role: "user".to_string(),
@@ -69,15 +53,18 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
 
     // REPL loop
     loop {
-        let user_input: String = Input::with_theme(&ColorfulTheme::default())
-            .with_prompt(if messages.is_empty() {
-                "What to do?"
-            } else {
-                "How to revise?"
-            })
-            .allow_empty(false)
-            .interact_text()
-            .unwrap();
+        // let user_input: String = Input::with_theme(&ColorfulTheme::default())
+        //     .with_prompt(if messages.is_empty() {
+        //         "What to do?"
+        //     } else {
+        //         "How to revise?"
+        //     })
+        //     .allow_empty(false)
+        //     .interact_text()
+        //     .unwrap();
+        let user_input = ctx
+            .get_user_input_via_editor("Put prompt here")
+            .expect("Failed to get user input");
 
         // Add the user's input as a new message
         messages.push(MessageSchema {
@@ -85,7 +72,6 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
             text: user_input.trim().to_string(),
         });
 
-        // Generate revision
         ctx.success("Generating revision...");
 
         let root_path = &ctx.corpora_config.root_path;
@@ -119,13 +105,8 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
                 continue;
             }
         };
-
-        ctx.print(&revision, dialoguer::console::Style::new().dim());
-        // println!("{}", relative_path.display());
-        ctx.print(
-            &format!("Revision for `{}`:", relative_path.display()),
-            dialoguer::console::Style::new().dim().magenta().on_green(),
-        );
+        ctx.dim(&revision);
+        ctx.highlight(&format!("Revision for `{}`:", relative_path.display()));
         messages.push(MessageSchema {
             role: "assistant".to_string(),
             text: revision.clone(),

--- a/rs/core/corpora_cli/src/commands/workon.rs
+++ b/rs/core/corpora_cli/src/commands/workon.rs
@@ -98,7 +98,7 @@ pub fn run(ctx: &Context, args: WorkonArgs) {
         };
 
         ctx.dim(&revision);
-        ctx.highlight(&format!("Revision for `{}`:", relative_path.display()));
+        ctx.highlight(&format!("^^Revision for `{}`^^", relative_path.display()));
         messages.push(MessageSchema {
             role: "assistant".to_string(),
             text: revision.clone(),

--- a/rs/core/corpora_cli/src/context/mod.rs
+++ b/rs/core/corpora_cli/src/context/mod.rs
@@ -2,9 +2,14 @@ pub mod auth;
 pub mod collector;
 pub mod config;
 
-use console::{Style, Term};
-use indicatif::{ProgressBar, ProgressStyle};
 use std::sync::Arc;
+
+use console::{Style, Term};
+// use dialoguer::Editor;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+use indicatif::{ProgressBar, ProgressStyle};
 
 use corpora_client::apis::configuration::Configuration;
 
@@ -151,4 +156,70 @@ impl Context {
         let dim_style = Style::new().dim();
         self.print(message, dim_style);
     }
+
+    /// Print a magenta message
+    /// Magenta messages are used for highlighting information
+    /// # Arguments
+    /// * `message` - The message to print.
+    pub fn magenta(&self, message: &str) {
+        let magenta_style = Style::new().magenta();
+        self.print(message, magenta_style);
+    }
+
+    /// Print a highlighted message
+    /// Highlighted messages are used for important information
+    /// # Arguments
+    /// * `message` - The message to print.
+    pub fn highlight(&self, message: &str) {
+        let style = Style::new().bold().green().on_magenta();
+        self.print(message, style);
+    }
+
+    /// Get user input via an editor
+    /// Opens the user's default editor with the provided content
+    /// # Arguments
+    /// * `initial_content` - The initial content to display in the editor.
+    /// # Returns
+    /// The edited content as a `String`.
+    pub fn get_user_input_via_editor(&self, initial_content: &str) -> Result<String, String> {
+        get_user_input_via_editor(initial_content)
+    }
+}
+
+pub fn get_user_input_via_editor(initial_content: &str) -> Result<String, String> {
+    // Create a temporary file
+    let temp_file =
+        NamedTempFile::new().map_err(|e| format!("Failed to create temp file: {}", e))?;
+
+    // Write the initial content to the temporary file
+    std::fs::write(temp_file.path(), initial_content)
+        .map_err(|e| format!("Failed to write to temp file: {}", e))?;
+
+    // Get the editor from $EDITOR or default to 'vim'
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vim".to_string());
+    let mut command = Command::new(&editor);
+
+    // Add flags for non-blocking editors
+    if editor.contains("code") {
+        command.arg("--wait");
+    } else if editor.contains("subl") {
+        command.arg("--wait");
+    } else if editor.contains("gedit") {
+        command.arg("--standalone");
+    }
+
+    // Open the file in the editor and wait for it to close
+    let status = command
+        .arg(temp_file.path())
+        .status()
+        .map_err(|e| format!("Failed to launch editor '{}': {}", editor, e))?;
+
+    // Check if the editor exited successfully
+    if !status.success() {
+        return Err(format!("Editor '{}' exited with a non-zero status", editor));
+    }
+
+    // Read the edited content back from the file
+    std::fs::read_to_string(temp_file.path())
+        .map_err(|e| format!("Failed to read edited file: {}", e))
 }

--- a/rs/core/corpora_cli/src/context/mod.rs
+++ b/rs/core/corpora_cli/src/context/mod.rs
@@ -200,9 +200,7 @@ pub fn get_user_input_via_editor(initial_content: &str) -> Result<String, String
     let mut command = Command::new(&editor);
 
     // Add flags for non-blocking editors
-    if editor.contains("code") {
-        command.arg("--wait");
-    } else if editor.contains("subl") {
+    if editor.contains("code") || editor.contains("subl") {
         command.arg("--wait");
     } else if editor.contains("gedit") {
         command.arg("--standalone");


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Replaced `dialoguer::Input` with `get_user_input_via_editor` for multiline input in `chat` and `workon` commands.
- Added new functions in `context` module for handling editor-based input and styled message printing.
- Updated `docker-compose.yaml` to include a commented-out `EDITOR` environment variable.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.rs</strong><dd><code>Switch to editor-based input for chat command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rs/core/corpora_cli/src/commands/chat.rs

<li>Removed the use of <code>dialoguer::Input</code> for user input.<br> <li> Introduced <code>get_user_input_via_editor</code> for multiline input.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/63/files#diff-60cfd986b6359a6be930cd43a2a5d02592c585dd6f79616350711570e6b8002f">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workon.rs</strong><dd><code>Use editor for input in workon command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rs/core/corpora_cli/src/commands/workon.rs

<li>Removed <code>dialoguer::Input</code> for user input.<br> <li> Added <code>get_user_input_via_editor</code> for multiline input.<br> <li> Simplified file path handling and printing.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/63/files#diff-e8486ee89ebf16ff450393704ed1bda8ca8222231ba8dc254270317294b85a76">+18/-45</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add editor-based input handling in context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rs/core/corpora_cli/src/context/mod.rs

<li>Added functions for printing styled messages.<br> <li> Implemented <code>get_user_input_via_editor</code> function.<br> <li> Introduced temporary file handling for editor input.<br>


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/63/files#diff-41b9c211f7b0be404e9d2653410776b6f936a15815d2a59a0b8d190a8eb5b916">+72/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yaml</strong><dd><code>Update docker-compose with editor variable comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yaml

- Commented out `EDITOR` environment variable.



</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/63/files#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information