### PR TITLE
feat(sync): noinput option for `sync`, `infer` tries again with error message

### DIFF
--- a/rs/core/corpora_cli/src/commands/infer.rs
+++ b/rs/core/corpora_cli/src/commands/infer.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-const MAX_RETRIES: u8 = 1;
+const MAX_RETRIES: u8 = 2;
 
 #[derive(Args)]
 pub struct InferArgs {
@@ -68,7 +68,7 @@ pub fn run(ctx: &Context, args: InferArgs) {
             messages.push(MessageSchema {
                 role: "user".to_string(),
                 text: format!(
-                    "Previous attempt failed. Here is the error output:\n```\n{}\n```",
+                    "Previous attempt failed. Here is the error output:\n```\n{}\n```\n Please fix the error and try again.",
                     error_msg
                 ),
             });
@@ -121,7 +121,7 @@ pub fn run(ctx: &Context, args: InferArgs) {
 
                     if attempts >= MAX_RETRIES {
                         ctx.error("Max retries reached. Aborting.");
-                        return;
+                        std::process::exit(1);
                     }
                     continue; // Retry with new AI request including error output
                 }

--- a/rs/core/corpora_cli/src/commands/mod.rs
+++ b/rs/core/corpora_cli/src/commands/mod.rs
@@ -15,7 +15,7 @@ pub enum Commands {
     #[command(about = "Chat the corpus")]
     Chat(chat::ChatArgs),
     #[command(about = "Find the diff and sync changes to the server")]
-    Sync,
+    Sync(sync::SyncArgs),
     #[command(about = "Work on a specific file")]
     Workon(workon::WorkonArgs),
     #[command(about = "Infer a file")]

--- a/rs/core/corpora_cli/src/main.rs
+++ b/rs/core/corpora_cli/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
 
     match cli.command {
         Commands::Init => commands::init::run(&ctx),
-        Commands::Sync => commands::sync::run(&ctx),
+        Commands::Sync(args) => commands::sync::run(&ctx, args),
         Commands::Chat(args) => commands::chat::run(&ctx, args),
         Commands::Workon(args) => commands::workon::run(&ctx, args),
         Commands::Infer(args) => commands::infer::run(&ctx, args),


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `noinput` option to `sync` command for auto-confirmation.

- Increased `MAX_RETRIES` for `infer` command to 2.

- Improved error handling in `infer` command with exit on max retries.

- Updated command argument handling in `main.rs`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>infer.rs</strong><dd><code>Improve retry logic and error handling in `infer` command</code></dd></summary>
<hr>

rs/core/corpora_cli/src/commands/infer.rs

<li>Increased <code>MAX_RETRIES</code> from 1 to 2.<br> <li> Enhanced error message with retry instructions.<br> <li> Changed behavior to exit on max retries.


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/66/files#diff-c20e828eb8033198bef8a012def9119f7bd35eea00374e0da68c1f82a3030baf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update `Sync` command to accept arguments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rs/core/corpora_cli/src/commands/mod.rs

- Added `SyncArgs` to `Sync` command.


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/66/files#diff-2550db3c9a489e434c19e201eeb07d19c4e95c3215c37342366b353df3c7e55d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync.rs</strong><dd><code>Add `noinput` option to `sync` command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rs/core/corpora_cli/src/commands/sync.rs

<li>Introduced <code>SyncArgs</code> struct with <code>noinput</code> option.<br> <li> Modified <code>run</code> function to handle <code>noinput</code> flag.


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/66/files#diff-95450b4ef279cd2f15cef75ca2ae11addb7aee0dddb6c9a63dc05c069604200d">+18/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Pass arguments to `Sync` command in main</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rs/core/corpora_cli/src/main.rs

- Updated `Sync` command to pass `SyncArgs`.


</details>


  </td>
  <td><a href="https://github.com/skyl/corpora/pull/66/files#diff-b55206acc7f68d38e478553c42b621440dee7688450587e15cffc94992f4cc8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>